### PR TITLE
Fix for empty array on getActiveChildNavs()

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -105,7 +105,7 @@ export class ConferenceApp {
     // If we are already on tabs just change the selected tab
     // don't setRoot again, this maintains the history stack of the
     // tabs even if changing them from the menu
-    if (this.nav.getActiveChildNavs() && page.index != undefined) {
+    if (this.nav.getActiveChildNavs().length && page.index != undefined) {
       this.nav.getActiveChildNavs()[0].select(page.index);
     // Set the root of the nav with params if it's a tab index
   } else {


### PR DESCRIPTION
Empty array `[]` will pass on `if (this.nav.getActiveChildNavs()&& page.index != undefined) {` and it will create exception on `this.nav.getActiveChildNavs()[0].select`