### PR TITLE
chore(config): remove crosswalk from config.xml

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -85,13 +85,6 @@
   <plugin name="cordova-plugin-console" spec="1.0.5"/>
   <plugin name="cordova-plugin-statusbar" spec="2.2.1"/>
   <plugin name="cordova-plugin-device" spec="1.1.4"/>
-  <plugin name="cordova-plugin-crosswalk-webview" spec="~2.2.0">
-    <variable name="XWALK_VERSION" value="22+"/>
-    <variable name="XWALK_LITEVERSION" value="xwalk_core_library_canary:17+"/>
-    <variable name="XWALK_COMMANDLINE" value="--disable-pull-to-refresh-effect"/>
-    <variable name="XWALK_MODE" value="embedded"/>
-    <variable name="XWALK_MULTIPLEAPK" value="true"/>
-  </plugin>
   <plugin name="cordova-plugin-splashscreen" spec="~4.0.1"/>
   <engine name="ios" spec="4.3.1"/>
   <engine name="android" spec="6.1.0"/>


### PR DESCRIPTION
Crosswalk is no longer actively developed and the market share of Android<5.0 is declining, so I don't think the "gold standard" ionic app should include it by default anymore. Also ionic2-app-base doesn't include it.