### PR TITLE
fix(scripts) add serve script to npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "ionic-app-scripts build",
     "clean": "ionic-app-scripts clean",
     "lint": "ionic-app-scripts lint",
+    "serve": "ionic-app-scripts serve",
     "ionic:build": "npm run build",
     "ionic:serve": "npm run serve",
     "ionic:lint": "npm run lint"


### PR DESCRIPTION
There is an `ionic:serve` task that calls the `serve` task but it doesn't actually exist. This PR is adding the script.