### PR TITLE
fix(about) change routing from about to support

### DIFF
--- a/src/pages/about-popover/about-popover.ts
+++ b/src/pages/about-popover/about-popover.ts
@@ -24,7 +24,7 @@ export class PopoverPage {
   ) { }
 
   support() {
-    this.app.getRootNav().push('SupportPage');
+    this.app.getRootNav().setRoot('SupportPage');
     this.viewCtrl.dismiss();
   }
 


### PR DESCRIPTION
The routing from the about pop-over wasn't routing correctly to support. The result was that you couldn't click any of the other links on the left nav bar.