### PR TITLE
chore(config): remove crosswalk from config.xml and package.json

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -73,13 +73,6 @@
     <preference name="SplashScreenDelay" value="3000" />
     <engine name="android" spec="^6.2.3" />
     <engine name="ios" spec="^4.5.2" />
-    <plugin name="cordova-plugin-crosswalk-webview" spec="^2.3.0">
-        <variable name="XWALK_VERSION" value="22+" />
-        <variable name="XWALK_LITEVERSION" value="xwalk_core_library_canary:17+" />
-        <variable name="XWALK_COMMANDLINE" value="--disable-pull-to-refresh-effect" />
-        <variable name="XWALK_MODE" value="embedded" />
-        <variable name="XWALK_MULTIPLEAPK" value="true" />
-    </plugin>
     <plugin name="cordova-plugin-device" spec="^1.1.6" />
     <plugin name="cordova-plugin-inappbrowser" spec="^1.7.1" />
     <plugin name="cordova-plugin-splashscreen" spec="^4.0.3" />

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@ionic/storage": "2.1.3",
     "cordova-android": "^6.2.3",
     "cordova-ios": "^4.5.2",
-    "cordova-plugin-crosswalk-webview": "^2.3.0",
     "cordova-plugin-device": "^1.1.6",
     "cordova-plugin-inappbrowser": "^1.7.1",
     "cordova-plugin-ionic-keyboard": "^2.0.2",
@@ -55,13 +54,6 @@
       "ios"
     ],
     "plugins": {
-      "cordova-plugin-crosswalk-webview": {
-        "XWALK_VERSION": "22+",
-        "XWALK_LITEVERSION": "xwalk_core_library_canary:17+",
-        "XWALK_COMMANDLINE": "--disable-pull-to-refresh-effect",
-        "XWALK_MODE": "embedded",
-        "XWALK_MULTIPLEAPK": "true"
-      },
       "cordova-plugin-device": {},
       "cordova-plugin-inappbrowser": {},
       "cordova-plugin-splashscreen": {},


### PR DESCRIPTION
Even though crosswalk was removed in #432 it was added right back in https://github.com/ionic-team/ionic-conference-app/commit/8a62ca419fe1cd823b25b1000eb5a11b4515e11e
Crosswalk is not being maintained anymore and this app fails for me when using newest android engine and crosswalk plugin with error about requiring to define `flavorDimensions` (though this is more crosswalk problem).