### PR TITLE
Change references to ng-toolkit with angular-toolkit

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -115,7 +115,7 @@
           }
         },
         "ionic-cordova-build": {
-          "builder": "@ionic/ng-toolkit:cordova-build",
+          "builder": "@ionic/angular-toolkit:cordova-build",
           "options": {
             "browserTarget": "app:build"
           },
@@ -126,7 +126,7 @@
           }
         },
         "ionic-cordova-serve": {
-          "builder": "@ionic/ng-toolkit:cordova-serve",
+          "builder": "@ionic/angular-toolkit:cordova-serve",
           "options": {
             "cordovaBuildTarget": "app:ionic-cordova-build",
             "devServerTarget": "app:serve"


### PR DESCRIPTION
I'm currently getting errors to run the app because of a reference to ng-toolkit. This PR fixes that.

`Could not find module "@ionic/ng-toolkit" from "/Users/fjansen/Workspaces/playground/ionic-conference-app".`