### PR TITLE
fix(speakers): Profile pics not loading when app uploaded in subfolder

### DIFF
--- a/src/assets/data/data.json
+++ b/src/assets/data/data.json
@@ -247,7 +247,7 @@
   "speakers": [
     {
       "name": "Burt Bear",
-      "profilePic": "/assets/img/speakers/bear.jpg",
+      "profilePic": "assets/img/speakers/bear.jpg",
       "twitter": "ionicframework",
       "about": "Burt is a Bear.",
       "location": "Everywhere",
@@ -257,7 +257,7 @@
     },
     {
       "name": "Charlie Cheetah",
-      "profilePic": "/assets/img/speakers/cheetah.jpg",
+      "profilePic": "assets/img/speakers/cheetah.jpg",
       "twitter": "ionicframework",
       "about": "Charlie is a Cheetah.",
       "location": "Everywhere",
@@ -267,7 +267,7 @@
     },
     {
       "name": "Donald Duck",
-      "profilePic": "/assets/img/speakers/duck.jpg",
+      "profilePic": "assets/img/speakers/duck.jpg",
       "twitter": "ionicframework",
       "about": "Donald is a Duck.",
       "location": "Everywhere",
@@ -277,7 +277,7 @@
     },
     {
       "name": "Eva Eagle",
-      "profilePic": "/assets/img/speakers/eagle.jpg",
+      "profilePic": "assets/img/speakers/eagle.jpg",
       "twitter": "ionicframework",
       "about": "Eva is an Eagle.",
       "location": "Everywhere",
@@ -287,7 +287,7 @@
     },
     {
       "name": "Ellie Elephant",
-      "profilePic": "/assets/img/speakers/elephant.jpg",
+      "profilePic": "assets/img/speakers/elephant.jpg",
       "twitter": "ionicframework",
       "about": "Ellie is an Elephant.",
       "location": "Everywhere",
@@ -297,7 +297,7 @@
     },
     {
       "name": "Gino Giraffe",
-      "profilePic": "/assets/img/speakers/giraffe.jpg",
+      "profilePic": "assets/img/speakers/giraffe.jpg",
       "twitter": "ionicframework",
       "about": "Gino is a Giraffe.",
       "location": "Everywhere",
@@ -307,7 +307,7 @@
     },
     {
       "name": "Isabella Iguana",
-      "profilePic": "/assets/img/speakers/iguana.jpg",
+      "profilePic": "assets/img/speakers/iguana.jpg",
       "twitter": "ionicframework",
       "about": "Isabella is an Iguana.",
       "location": "Everywhere",
@@ -317,7 +317,7 @@
     },
     {
       "name": "Karl Kitten",
-      "profilePic": "/assets/img/speakers/kitten.jpg",
+      "profilePic": "assets/img/speakers/kitten.jpg",
       "twitter": "ionicframework",
       "about": "Karl is a Kitten.",
       "location": "Everywhere",
@@ -327,7 +327,7 @@
     },
     {
       "name": "Lionel Lion",
-      "profilePic": "/assets/img/speakers/lion.jpg",
+      "profilePic": "assets/img/speakers/lion.jpg",
       "twitter": "ionicframework",
       "about": "Lionel is a Lion.",
       "location": "Everywhere",
@@ -337,7 +337,7 @@
     },
     {
       "name": "Molly Mouse",
-      "profilePic": "/assets/img/speakers/mouse.jpg",
+      "profilePic": "assets/img/speakers/mouse.jpg",
       "twitter": "ionicframework",
       "about": "Molly is a Mouse.",
       "location": "Everywhere",
@@ -347,7 +347,7 @@
     },
     {
       "name": "Paul Puppy",
-      "profilePic": "/assets/img/speakers/puppy.jpg",
+      "profilePic": "assets/img/speakers/puppy.jpg",
       "twitter": "ionicframework",
       "about": "Paul is a Puppy.",
       "location": "Everywhere",
@@ -357,7 +357,7 @@
     },
     {
       "name": "Rachel Rabbit",
-      "profilePic": "/assets/img/speakers/rabbit.jpg",
+      "profilePic": "assets/img/speakers/rabbit.jpg",
       "twitter": "ionicframework",
       "about": "Rachel is a Rabbit.",
       "location": "Everywhere",
@@ -367,7 +367,7 @@
     },
     {
       "name": "Ted Turtle",
-      "profilePic": "/assets/img/speakers/turtle.jpg",
+      "profilePic": "assets/img/speakers/turtle.jpg",
       "twitter": "ionicframework",
       "about": "Ted is a Turtle.",
       "location": "Everywhere",


### PR DESCRIPTION
Profile pics had an absolute path to `/assets/*` folder. Changed to relative path as `assets/*` so they can be loaded even when the app is served from a subfolder.