### PR TITLE
fix(testing): ION-SLIDE to ion-slide

### DIFF
--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -13,7 +13,7 @@ describe('new App', () => {
   });
   fit('should get the slides text', () => {
     page.navigateTo();
-    expect(page.getFirstSlide()).toBe('ION-SLIDE');
+    expect(page.getFirstSlide()).toBe('ion-slide');
     // console.log(page.getFirstSlide());
   });
 


### PR DESCRIPTION
When to be `ION-SLIDE` , testing is failed.

```
**************************************************
*                    Failures                    *
**************************************************

1) new App should get the slides text
  - Expected 'ion-slide' to be 'ION-SLIDE'.

```

ionic info

```
Ionic:

   Ionic CLI                     : 5.2.6 (/usr/local/lib/node_modules/ionic)
   Ionic Framework               : @ionic/angular 4.8.1
   @angular-devkit/build-angular : 0.801.3
   @angular-devkit/schematics    : 8.3.1
   @angular/cli                  : 8.3.1
   @ionic/angular-toolkit        : 2.0.0

Cordova:

   Cordova CLI       : 9.0.0
   Cordova Platforms : not available
   Cordova Plugins   : not available

Utility:

   cordova-res : 0.6.0 
   native-run  : not installed

System:

   ios-deploy : 2.0.0
   ios-sim    : 8.0.2
   NodeJS     : v10.16.2 (/usr/local/bin/node)
   npm        : 6.10.3
   OS         : macOS Mojave
   Xcode      : Xcode 10.3 Build version 10G8

```