### PR TITLE
show coordinates on map, select all on schedule filter

### DIFF
--- a/src/app/pages/map/map.html
+++ b/src/app/pages/map/map.html
@@ -4,6 +4,7 @@
       <ion-menu-button></ion-menu-button>
     </ion-buttons>
     <ion-title>Map</ion-title>
+    <p [hidden]="lat == null && lng == null" slot="end">Latitude: {{lat}}   ,   Longitude: {{lng}}</p>
   </ion-toolbar>
 </ion-header>
 

--- a/src/app/pages/map/map.scss
+++ b/src/app/pages/map/map.scss
@@ -8,6 +8,8 @@
 
   opacity: 0;
   transition: opacity 150ms ease-in;
+
+  color: black;
 }
 
 .show-map {

--- a/src/app/pages/map/map.ts
+++ b/src/app/pages/map/map.ts
@@ -13,10 +13,16 @@ import { darkStyle } from './map-dark-style';
 export class MapPage implements AfterViewInit {
   @ViewChild('mapCanvas', { static: true }) mapElement: ElementRef;
 
+  lat: number;
+  lng: number;
+
   constructor(
     @Inject(DOCUMENT) private doc: Document,
     public confData: ConferenceData,
-    public platform: Platform) {}
+    public platform: Platform) {
+      this.lat = null;
+      this.lng = null;
+    }
 
   async ngAfterViewInit() {
     const appEl = this.doc.querySelector('ion-app');
@@ -41,6 +47,11 @@ export class MapPage implements AfterViewInit {
         styles: style
       });
 
+      map.addListener('click',(e) => {
+        this.lat = e.latLng.lat();
+        this.lng = e.latLng.lng();
+      });
+
       mapData.forEach((markerData: any) => {
         const infoWindow = new googleMaps.InfoWindow({
           content: `<h5>${markerData.name}</h5>`
@@ -52,8 +63,12 @@ export class MapPage implements AfterViewInit {
           title: markerData.name
         });
 
-        marker.addListener('click', () => {
+        marker.addListener('click', (e) => {
           infoWindow.open(map, marker);
+          map.setZoom(16);
+          map.setCenter(e.latLng);
+          this.lat = e.latLng.lat();
+          this.lng = e.latLng.lng();
         });
       });
 

--- a/src/app/pages/schedule-filter/schedule-filter.html
+++ b/src/app/pages/schedule-filter/schedule-filter.html
@@ -2,7 +2,8 @@
   <ion-toolbar>
     <ion-buttons slot="start">
       <ion-button *ngIf="ios" (click)="dismiss()">Cancel</ion-button>
-      <ion-button *ngIf="!ios" (click)="selectAll(false)">Reset</ion-button>
+      <ion-button *ngIf="!ios && isReset" (click)="selectAll(false)">Reset</ion-button>
+      <ion-button *ngIf="!ios && !isReset" (click)="selectAll(true)">Select All</ion-button>
     </ion-buttons>
 
     <ion-title>

--- a/src/app/pages/schedule-filter/schedule-filter.ts
+++ b/src/app/pages/schedule-filter/schedule-filter.ts
@@ -11,6 +11,7 @@ import { ConferenceData } from '../../providers/conference-data';
 })
 export class ScheduleFilterPage {
   ios: boolean;
+  isReset = true;
 
   tracks: {name: string, icon: string, isChecked: boolean}[] = [];
 
@@ -43,6 +44,7 @@ export class ScheduleFilterPage {
     this.tracks.forEach(track => {
       track.isChecked = check;
     });
+    this.isReset = check;
   }
 
   applyFilters() {


### PR DESCRIPTION
-Pan to the marker's location after clicking any one of the markers.
-Show coordinates on map page after clicking on the map.
-Marker's info window content is now visible in dark mode.
-Select all is now callable after resetting the schedule filter.
