### PR TITLE
refactor: remove unneeded dynamic font scaling opt-in

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@capacitor/keyboard": "4.1.1",
         "@capacitor/splash-screen": "4.1.4",
         "@capacitor/status-bar": "4.1.1",
-        "@ionic/angular": "^7.6.2-dev.11704998705.1e1f9850",
+        "@ionic/angular": "^7.7.2-dev.11707425083.192d8103",
         "@ionic/storage-angular": "^4.0.0",
         "cordova-plugin-inappbrowser": "5.0.0",
         "core-js": "^3.6.4",
@@ -3951,11 +3951,11 @@
       "dev": true
     },
     "node_modules/@ionic/angular": {
-      "version": "7.6.2-dev.11704998705.1e1f9850",
-      "resolved": "https://registry.npmjs.org/@ionic/angular/-/angular-7.6.2-dev.11704998705.1e1f9850.tgz",
-      "integrity": "sha512-3SiUlsgAhVNi4MHxiEFzLaQDIiNGVV8ViAF8/ZTpm/3ukbbJb/+7zJ8xWZlmyjcudropIlAEw5gxErVIvMPTyA==",
+      "version": "7.7.2-dev.11707425083.192d8103",
+      "resolved": "https://registry.npmjs.org/@ionic/angular/-/angular-7.7.2-dev.11707425083.192d8103.tgz",
+      "integrity": "sha512-QkzVRgTm57P+AB8Ht8qbqk+iFuvyE874w/NQ8ePG5efR7xC77wG0DnWzvOKF6orTeQd8S96gUrWiR5x1fkQDqQ==",
       "dependencies": {
-        "@ionic/core": "7.6.2-dev.11704998705.1e1f9850",
+        "@ionic/core": "7.7.2-dev.11707425083.192d8103",
         "ionicons": "^7.0.0",
         "jsonc-parser": "^3.0.0",
         "tslib": "^2.3.0"
@@ -4926,12 +4926,12 @@
       "dev": true
     },
     "node_modules/@ionic/core": {
-      "version": "7.6.2-dev.11704998705.1e1f9850",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.6.2-dev.11704998705.1e1f9850.tgz",
-      "integrity": "sha512-/Vdrgyq8aFr68KaNrChuejCUGppj+IbwR1CmZm9/S0+w12mtCyVM5+6VVq9CLAVi0YG7m2AK2S5ENtK+hv4Ljw==",
+      "version": "7.7.2-dev.11707425083.192d8103",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.7.2-dev.11707425083.192d8103.tgz",
+      "integrity": "sha512-eU8Jw9owrswoEtePoK9EU2PipoIVY8/3hm5U1o94s9wguUGW9Jk+gtr61EgteU8ZiXcjyFMw+YsrHSAZfZJu+w==",
       "dependencies": {
-        "@stencil/core": "^4.8.2",
-        "ionicons": "^7.2.1",
+        "@stencil/core": "^4.12.0",
+        "ionicons": "^7.2.2",
         "tslib": "^2.1.0"
       }
     },
@@ -6096,9 +6096,9 @@
       "dev": true
     },
     "node_modules/@stencil/core": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.9.1.tgz",
-      "integrity": "sha512-FB3vQR2xbX8RkiKdvBRj6jAe2VunKgB4U5hWSbpdcg/GhZrwOhsEgkGUGa8hGm9bgEUpIu16in1zFqziPyBEFw==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.12.1.tgz",
+      "integrity": "sha512-l7UUCEV+4Yr1i6BL2DGSQPAzM3x/V4Fx9n9Z0/gdAgX11I25xY0MnH5jbQ69ug6ms/8KUV6SouS1R7MjjM/JnQ==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -25768,11 +25768,11 @@
       "dev": true
     },
     "@ionic/angular": {
-      "version": "7.6.2-dev.11704998705.1e1f9850",
-      "resolved": "https://registry.npmjs.org/@ionic/angular/-/angular-7.6.2-dev.11704998705.1e1f9850.tgz",
-      "integrity": "sha512-3SiUlsgAhVNi4MHxiEFzLaQDIiNGVV8ViAF8/ZTpm/3ukbbJb/+7zJ8xWZlmyjcudropIlAEw5gxErVIvMPTyA==",
+      "version": "7.7.2-dev.11707425083.192d8103",
+      "resolved": "https://registry.npmjs.org/@ionic/angular/-/angular-7.7.2-dev.11707425083.192d8103.tgz",
+      "integrity": "sha512-QkzVRgTm57P+AB8Ht8qbqk+iFuvyE874w/NQ8ePG5efR7xC77wG0DnWzvOKF6orTeQd8S96gUrWiR5x1fkQDqQ==",
       "requires": {
-        "@ionic/core": "7.6.2-dev.11704998705.1e1f9850",
+        "@ionic/core": "7.7.2-dev.11707425083.192d8103",
         "ionicons": "^7.0.0",
         "jsonc-parser": "^3.0.0",
         "tslib": "^2.3.0"
@@ -26514,12 +26514,12 @@
       }
     },
     "@ionic/core": {
-      "version": "7.6.2-dev.11704998705.1e1f9850",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.6.2-dev.11704998705.1e1f9850.tgz",
-      "integrity": "sha512-/Vdrgyq8aFr68KaNrChuejCUGppj+IbwR1CmZm9/S0+w12mtCyVM5+6VVq9CLAVi0YG7m2AK2S5ENtK+hv4Ljw==",
+      "version": "7.7.2-dev.11707425083.192d8103",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.7.2-dev.11707425083.192d8103.tgz",
+      "integrity": "sha512-eU8Jw9owrswoEtePoK9EU2PipoIVY8/3hm5U1o94s9wguUGW9Jk+gtr61EgteU8ZiXcjyFMw+YsrHSAZfZJu+w==",
       "requires": {
-        "@stencil/core": "^4.8.2",
-        "ionicons": "^7.2.1",
+        "@stencil/core": "^4.12.0",
+        "ionicons": "^7.2.2",
         "tslib": "^2.1.0"
       }
     },
@@ -27401,9 +27401,9 @@
       "dev": true
     },
     "@stencil/core": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.9.1.tgz",
-      "integrity": "sha512-FB3vQR2xbX8RkiKdvBRj6jAe2VunKgB4U5hWSbpdcg/GhZrwOhsEgkGUGa8hGm9bgEUpIu16in1zFqziPyBEFw=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.12.1.tgz",
+      "integrity": "sha512-l7UUCEV+4Yr1i6BL2DGSQPAzM3x/V4Fx9n9Z0/gdAgX11I25xY0MnH5jbQ69ug6ms/8KUV6SouS1R7MjjM/JnQ=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@capacitor/keyboard": "4.1.1",
     "@capacitor/splash-screen": "4.1.4",
     "@capacitor/status-bar": "4.1.1",
-    "@ionic/angular": "^7.6.2-dev.11704998705.1e1f9850",
+    "@ionic/angular": "^7.7.2-dev.11707425083.192d8103",
     "@ionic/storage-angular": "^4.0.0",
     "cordova-plugin-inappbrowser": "5.0.0",
     "core-js": "^3.6.4",

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -2,11 +2,3 @@
   /* stylelint-disable-next-line declaration-no-important */
   display: none !important;
 }
-
-html {
-  /*
-   * For more information on dynamic font scaling, visit the documentation:
-   * https://ionicframework.com/docs/layout/dynamic-font-scaling
-   */
-  --ion-dynamic-font: var(--ion-default-dynamic-font);
-}


### PR DESCRIPTION
In https://github.com/ionic-team/ionic-framework/pull/28966, we enabled dynamic font scaling by default. As a result, the CSS that manually opts into it is no longer needed.

The dev build contains the latest Ionic v8 work, including the aforementioned PR.