### PR TITLE
refactor(app): update paths, order and naming for latest v8

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -32,11 +32,11 @@
             ],
             "styles": [
               {
-                "input": "src/theme/variables.scss",
+                "input": "src/global.scss",
                 "inject": true
               },
               {
-                "input": "src/global.scss",
+                "input": "src/theme/variables.scss",
                 "inject": true
               }
             ],
@@ -117,11 +117,11 @@
             "karmaConfig": "src/karma.conf.js",
             "styles": [
               {
-                "input": "src/theme/variables.scss",
+                "input": "src/global.scss",
                 "inject": true
               },
               {
-                "input": "src/global.scss",
+                "input": "src/theme/variables.scss",
                 "inject": true
               }
             ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@capacitor/keyboard": "4.1.1",
         "@capacitor/splash-screen": "4.1.4",
         "@capacitor/status-bar": "4.1.1",
-        "@ionic/angular": "^7.7.2-dev.11707425083.192d8103",
+        "@ionic/angular": "^8.0.0-rc.1",
         "@ionic/storage-angular": "^4.0.0",
         "cordova-plugin-inappbrowser": "5.0.0",
         "core-js": "^3.6.4",
@@ -3951,21 +3951,21 @@
       "dev": true
     },
     "node_modules/@ionic/angular": {
-      "version": "7.7.2-dev.11707425083.192d8103",
-      "resolved": "https://registry.npmjs.org/@ionic/angular/-/angular-7.7.2-dev.11707425083.192d8103.tgz",
-      "integrity": "sha512-QkzVRgTm57P+AB8Ht8qbqk+iFuvyE874w/NQ8ePG5efR7xC77wG0DnWzvOKF6orTeQd8S96gUrWiR5x1fkQDqQ==",
+      "version": "8.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@ionic/angular/-/angular-8.0.0-rc.1.tgz",
+      "integrity": "sha512-lkccxmxhGD0FbyJWQSOEGC5YUOWz7p9rkU7DQR4PXWFV67PV040mygHXX7WWWDCn4UfZXETZTbGQdZaBdeGnRA==",
       "dependencies": {
-        "@ionic/core": "7.7.2-dev.11707425083.192d8103",
+        "@ionic/core": "8.0.0-rc.1",
         "ionicons": "^7.0.0",
         "jsonc-parser": "^3.0.0",
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/core": ">=14.0.0",
-        "@angular/forms": ">=14.0.0",
-        "@angular/router": ">=14.0.0",
+        "@angular/core": ">=16.0.0",
+        "@angular/forms": ">=16.0.0",
+        "@angular/router": ">=16.0.0",
         "rxjs": ">=7.5.0",
-        "zone.js": ">=0.11.0"
+        "zone.js": ">=0.13.0"
       }
     },
     "node_modules/@ionic/angular-toolkit": {
@@ -4926,11 +4926,11 @@
       "dev": true
     },
     "node_modules/@ionic/core": {
-      "version": "7.7.2-dev.11707425083.192d8103",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.7.2-dev.11707425083.192d8103.tgz",
-      "integrity": "sha512-eU8Jw9owrswoEtePoK9EU2PipoIVY8/3hm5U1o94s9wguUGW9Jk+gtr61EgteU8ZiXcjyFMw+YsrHSAZfZJu+w==",
+      "version": "8.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-8.0.0-rc.1.tgz",
+      "integrity": "sha512-pnpzoMyKgIlySVNJVMYSL1UTFGC+RwGyKGGlEyfWxpVk+WfLSmeTc7IoTlUAmc8tygOJWZuv5nP19pYVgeisjg==",
       "dependencies": {
-        "@stencil/core": "^4.12.0",
+        "@stencil/core": "^4.12.2",
         "ionicons": "^7.2.2",
         "tslib": "^2.1.0"
       }
@@ -6096,9 +6096,9 @@
       "dev": true
     },
     "node_modules/@stencil/core": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.12.1.tgz",
-      "integrity": "sha512-l7UUCEV+4Yr1i6BL2DGSQPAzM3x/V4Fx9n9Z0/gdAgX11I25xY0MnH5jbQ69ug6ms/8KUV6SouS1R7MjjM/JnQ==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.15.0.tgz",
+      "integrity": "sha512-C5syM3chCyxX0Os5M+ZWrBujjqwUfrTb87YiLr8RC+kMTmIpnRvvtj8/s3QYDGdDENGRxGkBpeboVh82IGqk0w==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -13044,9 +13044,9 @@
       }
     },
     "node_modules/ionicons": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-7.2.2.tgz",
-      "integrity": "sha512-I3iYIfc9Q9FRifWyFSwTAvbEABWlWY32i0sAVDDPGYnaIZVugkLCZFbEcrphW6ixVPg8tt1oLwalo/JJwbEqnA==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-7.3.1.tgz",
+      "integrity": "sha512-1boG4EQTBBpQ4/0PU60Yi78Iw/k8iNtKu9c0NmsbzHGnWAcwpiovG9Wi/rk5UlF+DC+CR4XDCxKo91YqvAxkww==",
       "dependencies": {
         "@stencil/core": "^4.0.3"
       }
@@ -25768,11 +25768,11 @@
       "dev": true
     },
     "@ionic/angular": {
-      "version": "7.7.2-dev.11707425083.192d8103",
-      "resolved": "https://registry.npmjs.org/@ionic/angular/-/angular-7.7.2-dev.11707425083.192d8103.tgz",
-      "integrity": "sha512-QkzVRgTm57P+AB8Ht8qbqk+iFuvyE874w/NQ8ePG5efR7xC77wG0DnWzvOKF6orTeQd8S96gUrWiR5x1fkQDqQ==",
+      "version": "8.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@ionic/angular/-/angular-8.0.0-rc.1.tgz",
+      "integrity": "sha512-lkccxmxhGD0FbyJWQSOEGC5YUOWz7p9rkU7DQR4PXWFV67PV040mygHXX7WWWDCn4UfZXETZTbGQdZaBdeGnRA==",
       "requires": {
-        "@ionic/core": "7.7.2-dev.11707425083.192d8103",
+        "@ionic/core": "8.0.0-rc.1",
         "ionicons": "^7.0.0",
         "jsonc-parser": "^3.0.0",
         "tslib": "^2.3.0"
@@ -26514,11 +26514,11 @@
       }
     },
     "@ionic/core": {
-      "version": "7.7.2-dev.11707425083.192d8103",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.7.2-dev.11707425083.192d8103.tgz",
-      "integrity": "sha512-eU8Jw9owrswoEtePoK9EU2PipoIVY8/3hm5U1o94s9wguUGW9Jk+gtr61EgteU8ZiXcjyFMw+YsrHSAZfZJu+w==",
+      "version": "8.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-8.0.0-rc.1.tgz",
+      "integrity": "sha512-pnpzoMyKgIlySVNJVMYSL1UTFGC+RwGyKGGlEyfWxpVk+WfLSmeTc7IoTlUAmc8tygOJWZuv5nP19pYVgeisjg==",
       "requires": {
-        "@stencil/core": "^4.12.0",
+        "@stencil/core": "^4.12.2",
         "ionicons": "^7.2.2",
         "tslib": "^2.1.0"
       }
@@ -27401,9 +27401,9 @@
       "dev": true
     },
     "@stencil/core": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.12.1.tgz",
-      "integrity": "sha512-l7UUCEV+4Yr1i6BL2DGSQPAzM3x/V4Fx9n9Z0/gdAgX11I25xY0MnH5jbQ69ug6ms/8KUV6SouS1R7MjjM/JnQ=="
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.15.0.tgz",
+      "integrity": "sha512-C5syM3chCyxX0Os5M+ZWrBujjqwUfrTb87YiLr8RC+kMTmIpnRvvtj8/s3QYDGdDENGRxGkBpeboVh82IGqk0w=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",
@@ -32659,9 +32659,9 @@
       }
     },
     "ionicons": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-7.2.2.tgz",
-      "integrity": "sha512-I3iYIfc9Q9FRifWyFSwTAvbEABWlWY32i0sAVDDPGYnaIZVugkLCZFbEcrphW6ixVPg8tt1oLwalo/JJwbEqnA==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-7.3.1.tgz",
+      "integrity": "sha512-1boG4EQTBBpQ4/0PU60Yi78Iw/k8iNtKu9c0NmsbzHGnWAcwpiovG9Wi/rk5UlF+DC+CR4XDCxKo91YqvAxkww==",
       "requires": {
         "@stencil/core": "^4.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@capacitor/keyboard": "4.1.1",
     "@capacitor/splash-screen": "4.1.4",
     "@capacitor/status-bar": "4.1.1",
-    "@ionic/angular": "^7.7.2-dev.11707425083.192d8103",
+    "@ionic/angular": "^8.0.0-rc.1",
     "@ionic/storage-angular": "^4.0.0",
     "cordova-plugin-inappbrowser": "5.0.0",
     "core-js": "^3.6.4",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
-<ion-app [class.ion-theme-dark]="dark">
+<ion-app [class.ion-palette-dark]="dark">
   <ion-split-pane contentId="main-content">
 
     <ion-menu contentId="main-content">

--- a/src/app/pages/map/map.ts
+++ b/src/app/pages/map/map.ts
@@ -22,7 +22,7 @@ export class MapPage implements AfterViewInit {
     const appEl = this.doc.querySelector('ion-app');
     let isDark = false;
     let style = [];
-    if (appEl.classList.contains('dark-theme')) {
+    if (appEl.classList.contains('ion-palette-dark')) {
       style = darkStyle;
     }
 
@@ -66,7 +66,7 @@ export class MapPage implements AfterViewInit {
       mutations.forEach((mutation) => {
         if (mutation.attributeName === 'class') {
           const el = mutation.target as HTMLElement;
-          isDark = el.classList.contains('dark-theme');
+          isDark = el.classList.contains('ion-palette-dark');
           if (map && isDark) {
             map.setOptions({styles: darkStyle});
           } else if (map) {

--- a/src/global.scss
+++ b/src/global.scss
@@ -10,19 +10,19 @@
  */
 
 /* Core CSS required for Ionic components to work properly */
-@import "~@ionic/angular/css/core.css";
+@import "@ionic/angular/css/core.css";
 
 /* Basic CSS for apps built with Ionic */
-@import "~@ionic/angular/css/normalize.css";
-@import "~@ionic/angular/css/structure.css";
-@import "~@ionic/angular/css/typography.css";
+@import "@ionic/angular/css/normalize.css";
+@import "@ionic/angular/css/structure.css";
+@import "@ionic/angular/css/typography.css";
 
 /* Optional CSS utils that can be commented out */
-@import "~@ionic/angular/css/padding.css";
-@import "~@ionic/angular/css/float-elements.css";
-@import "~@ionic/angular/css/text-alignment.css";
-@import "~@ionic/angular/css/text-transformation.css";
-@import "~@ionic/angular/css/flex-utils.css";
+@import "@ionic/angular/css/padding.css";
+@import "@ionic/angular/css/float-elements.css";
+@import "@ionic/angular/css/text-alignment.css";
+@import "@ionic/angular/css/text-transformation.css";
+@import "@ionic/angular/css/flex-utils.css";
 
 
 /*
@@ -42,6 +42,6 @@
  * https://ionicframework.com/docs/theming/dark-mode
  */
 
-// @import "~@ionic/angular/css/palettes/dark.always.css";
-// @import "~@ionic/angular/css/palettes/dark.system.css";
-@import "~@ionic/angular/css/palettes/dark.class.css";
+// @import "@ionic/angular/css/palettes/dark.always.css";
+// @import "@ionic/angular/css/palettes/dark.system.css";
+@import "@ionic/angular/css/palettes/dark.class.css";

--- a/src/global.scss
+++ b/src/global.scss
@@ -36,7 +36,7 @@
 
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Mode
  * -----------------------------------------------------
  * For more info, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/src/global.scss
+++ b/src/global.scss
@@ -42,6 +42,6 @@
  * https://ionicframework.com/docs/theming/dark-mode
  */
 
-// @import "~@ionic/angular/css/themes/dark.always.css";
-// @import "~@ionic/angular/css/themes/dark.system.css";
-@import "~@ionic/angular/css/themes/dark.class.css";
+// @import "~@ionic/angular/css/palettes/dark.always.css";
+// @import "~@ionic/angular/css/palettes/dark.system.css";
+@import "~@ionic/angular/css/palettes/dark.class.css";


### PR DESCRIPTION
Updates the following for v8:

- Uses the latest version of `@ionic/angular@next`
- Renames `css/themes` to `css/palettes` for dark mode imports
- Updates `ion-theme-dark` to `ion-palette-dark`
- Updates the order of `variables.scss` and `globals.scss` per the [migration guide](https://ionicframework.com/docs/v8/updating/8-0#angular-only-angularjson-css-import-order)
- Removes unnecessary tildes from Sass imports